### PR TITLE
Homebrew Caskを更新するPRを自動で作るGitHub ActionsをBUMP_CASK_TOKENに変更

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: macauley/action-homebrew-bump-cask@v1.0.0
         with:
           # Required, custom GitHub access token with only the 'public_repo' scope enabled
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BUMP_CASK_TOKEN }}
           tap: VOICEVOX/voicevox
           cask: voicevox, voicevox-preview
           livecheck: true


### PR DESCRIPTION
## 内容

タイトルの通りです。
（`workflow`権限がなぜ必要なのかちょっとわかってませんが）

## 関連 Issue

- https://github.com/VOICEVOX/homebrew-voicevox/pull/4

## その他

@y-chan 共有です 🙏 
`BUMP_CASK_TOKEN`には、public_repoとworkflowを有効にしたパーソナルアクセストークンを設定しています。

