### PR TITLE
Caskが変更されていないときはCIでテストが走らないようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,8 @@ name: CI
 
 on:
   pull_request:
-    paths-ignore:
-      - Casks/*-dev.rb
-      - Casks/*-preview.rb
+    paths:
+      - Casks/voicevox.rb
 
 env:
   HOMEBREW_DEVELOPER: 1


### PR DESCRIPTION
## 内容

`Casks/voicevox.rb` が変更されていないときはCIのテストが走らないようにします

## 関連

https://github.com/VOICEVOX/homebrew-voicevox/pull/9#issuecomment-1806776266
