### PR TITLE
自動マージが動かない問題がおそらく修正されます2

### DIFF
--- a/.github/workflows/DANGEROUS-auto-merge.yml
+++ b/.github/workflows/DANGEROUS-auto-merge.yml
@@ -1,9 +1,9 @@
-name: Auto merge
+name: "[DANGEROUS] Auto merge"
 
 on:
   pull_request_target:
-    branches: [ main ]
-    types: [ labeled ]
+    branches: [main]
+    types: [labeled]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,7 +1,7 @@
 name: Auto merge
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     types: [ labeled ]
 


### PR DESCRIPTION
## 内容

フォークしたリポジトリからPRが作成されたとき、Actionsのトリガーが `pull_request` の場合と `pull_request_target` の場合では実行コンテキストと `secrets.GITHUB_TOKEN` に付与されるアクセス許可が変わるそうです
アクセス許可が足りなくて実行に失敗していると思われるのでトリガーを `pull_request_target` に変更しました

参考: [GitHub Actionの`on: pull_request`と`on: pull_request_target`の違いMEMO - Madogiwa Blog](https://madogiwa0124.hatenablog.com/entry/2022/05/29/110148)
ドキュメント: https://docs.github.com/ja/actions/using-workflows/events-that-trigger-workflows#pull_request_target

## 関連

- #8 
- https://github.com/VOICEVOX/homebrew-voicevox/pull/11#issuecomment-1818042495

## その他

度々すみませんがマージと #11 のリベースを試していただきたいです🙇‍♂️