### PR TITLE
auto-mergeのフォーマットエラーをなくす

### DIFF
--- a/.github/workflows/DANGEROUS-auto-merge.yml
+++ b/.github/workflows/DANGEROUS-auto-merge.yml
@@ -8,17 +8,6 @@ on:
 permissions:
   pull-requests: write
   contents: write
-  actions: read
-  checks: read
-  deployments: read
-  id-token: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  repository-projects: read
-  security-events: read
-  statuses: read
 
 jobs:
   auto-merge:


### PR DESCRIPTION
## 内容

リポジトリ側のコードがワークフローで使われるようになった関係で、このエラーを先になくしておかないといけないことに気づいたので修正します。

## 関連 Issue

- https://github.com/VOICEVOX/homebrew-voicevox/pull/17
- https://github.com/VOICEVOX/homebrew-voicevox/pull/11

## その他

多分全部いらないはずなので削除してみました。
