### PR TITLE
dev版リリースcaskの自動マージが失敗しないように修正する

### DIFF
--- a/Casks/voicevox-dev.rb
+++ b/Casks/voicevox-dev.rb
@@ -2,7 +2,7 @@ cask "voicevox-dev" do
   version "0.15.0-dev"
   sha256 :no_check
 
-  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.dmg",
+  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.#{version}.dmg",
       verified: "github.com/VOICEVOX/voicevox/"
   name "VOICEVOX"
   desc "Free, medium-quality text-to-speech software"


### PR DESCRIPTION
## 内容

リリースファイルの名前が変わってdev版リリースの自動マージが失敗しているのでcaskファイルを修正しました
マージ後に `bump-voicevox-dev-0.16.0-dev` ブランチのリベースをお願い致します🙇‍♂️

## 関連 PR

#25 
