### PR TITLE
プレビュー版リリースcaskの自動マージが失敗しないように修正する

### DIFF
--- a/Casks/voicevox-preview.rb
+++ b/Casks/voicevox-preview.rb
@@ -2,7 +2,7 @@ cask "voicevox-preview" do
   version "0.15.0-preview.5"
   sha256 "606600fa10d7892b9a602d6a9983d952df3d4a16f5d4e4b61f9268d9029ed221"
 
-  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.dmg",
+  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.#{version}.dmg",
       verified: "github.com/VOICEVOX/voicevox/"
   name "VOICEVOX"
   desc "Free, medium-quality text-to-speech software"

--- a/Casks/voicevox-preview.rb
+++ b/Casks/voicevox-preview.rb
@@ -1,5 +1,5 @@
 cask "voicevox-preview" do
-  version "0.15.0-preview.5"
+  version "0.16.0-preview.0"
   sha256 "606600fa10d7892b9a602d6a9983d952df3d4a16f5d4e4b61f9268d9029ed221"
 
   url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.#{version}.dmg",

--- a/Casks/voicevox-preview.rb
+++ b/Casks/voicevox-preview.rb
@@ -1,6 +1,6 @@
 cask "voicevox-preview" do
   version "0.16.0-preview.0"
-  sha256 "606600fa10d7892b9a602d6a9983d952df3d4a16f5d4e4b61f9268d9029ed221"
+  sha256 "94ab314506baedf5463a6170d47d72b2e3b08a310dea2ce383240aa5e325dd94"
 
   url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.#{version}.dmg",
       verified: "github.com/VOICEVOX/voicevox/"


### PR DESCRIPTION
## 内容

リリースファイルの命名が変わったのでそれに合わせてcaskファイルを修正しました
そのままだとCIでエラーになるのでバージョンも上げました
