### PR TITLE
テスト用のactionから不要な処理を削除する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,6 @@ jobs:
       - name: Gather cask information
         id: info
         run: |
-          brew tap homebrew/cask-versions
           brew ruby <<'EOF'
             require 'cask/cask_loader'
             require 'cask/installer'


### PR DESCRIPTION
## 内容

元にしたリポジトリのPR (https://github.com/Homebrew/homebrew-cask/pull/172782) で `brew tap homebrew/cask-versions` が削除されていたので同じように修正しました。
このコマンドは非推奨になったようです。

## その他

なし
