### PR TITLE
Version区切り文字を公式Caskと同じように`@`にする

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -14,6 +14,6 @@ jobs:
           # Required, custom GitHub access token with only the 'public_repo' scope enabled
           token: ${{ secrets.BUMP_CASK_TOKEN }}
           tap: VOICEVOX/voicevox
-          cask: voicevox, voicevox-dev, voicevox-preview
+          cask: voicevox, voicevox@dev, voicevox@preview
           livecheck: true
           dryrun: false

--- a/Casks/voicevox.rb
+++ b/Casks/voicevox.rb
@@ -14,8 +14,8 @@ cask "voicevox" do
   end
 
   conflicts_with cask: [
-    "voicevox-dev",
-    "voicevox-preview",
+    "voicevox@dev",
+    "voicevox@preview",
   ]
 
   app "VOICEVOX.app"

--- a/Casks/voicevox@dev.rb
+++ b/Casks/voicevox@dev.rb
@@ -1,8 +1,9 @@
-cask "voicevox-preview" do
-  version "0.16.0-preview.1"
-  sha256 "14b48d4a3723fd9fc211e5c350f7563b56613ab981258038c3fda302acb17f0b"
+cask "voicevox@dev" do
+  arch arm: "arm64", intel: "x64"
+  version "0.20.0-dev"
+  sha256 :no_check
 
-  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.#{version}.dmg",
+  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.#{version}-#{arch}.dmg",
       verified: "github.com/VOICEVOX/voicevox/"
   name "VOICEVOX"
   desc "Free, medium-quality text-to-speech and singing synthesizer software"
@@ -10,22 +11,20 @@ cask "voicevox-preview" do
 
   livecheck do
     url :url
-    regex(/(\d+(?:\.\d+)*-preview\.\d+)$/i)
+    regex(/(\d+(?:\.\d+)*-dev)$/i)
   end
 
   conflicts_with cask: [
     "voicevox",
-    "voicevox-dev",
+    "voicevox@preview",
   ]
 
   app "VOICEVOX.app"
 
   zap trash: [
     "~/Library/Application Support/voicevox",
-    "~/Library/Application Support/voicevox-cpu",
     "~/Library/Application Support/voicevox-engine",
     "~/Library/Logs/voicevox",
-    "~/Library/Logs/voicevox-cpu",
     "~/Library/Preferences/jp.hiroshiba.voicevox.plist",
     "~/Library/Saved Application State/jp.hiroshiba.voicevox.savedState",
   ]

--- a/Casks/voicevox@preview.rb
+++ b/Casks/voicevox@preview.rb
@@ -1,9 +1,8 @@
-cask "voicevox-dev" do
-  arch arm: "arm64", intel: "x64"
-  version "0.20.0-dev"
-  sha256 :no_check
+cask "voicevox@preview" do
+  version "0.16.0-preview.1"
+  sha256 "14b48d4a3723fd9fc211e5c350f7563b56613ab981258038c3fda302acb17f0b"
 
-  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.#{version}-#{arch}.dmg",
+  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.#{version}.dmg",
       verified: "github.com/VOICEVOX/voicevox/"
   name "VOICEVOX"
   desc "Free, medium-quality text-to-speech and singing synthesizer software"
@@ -11,20 +10,22 @@ cask "voicevox-dev" do
 
   livecheck do
     url :url
-    regex(/(\d+(?:\.\d+)*-dev)$/i)
+    regex(/(\d+(?:\.\d+)*-preview\.\d+)$/i)
   end
 
   conflicts_with cask: [
     "voicevox",
-    "voicevox-preview",
+    "voicevox@dev",
   ]
 
   app "VOICEVOX.app"
 
   zap trash: [
     "~/Library/Application Support/voicevox",
+    "~/Library/Application Support/voicevox-cpu",
     "~/Library/Application Support/voicevox-engine",
     "~/Library/Logs/voicevox",
+    "~/Library/Logs/voicevox-cpu",
     "~/Library/Preferences/jp.hiroshiba.voicevox.plist",
     "~/Library/Saved Application State/jp.hiroshiba.voicevox.savedState",
   ]

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -1,4 +1,4 @@
 {
-  "voicevox-dev": "all",
-  "voicevox-preview": "all"
+  "voicevox@dev": "all",
+  "voicevox@preview": "all"
 }

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -1,0 +1,4 @@
+{
+  "voicevox-dev": "voicevox@dev",
+  "voicevox-preview": "voicevox@preview"
+}


### PR DESCRIPTION
## 内容
Version区切り文字を公式Caskと同じように`@`にします
次のような利点が得られます:
- 後で公式Caskに移す時、摩擦を減らすことができる。
- ユーザーが公式Caskと同じ方式で使用できる。

## 関連 Issue
Resolve #44
