### PR TITLE
GitHub Actionsが失敗するのを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 # ci.yml
 #
 # Copyright © 2013, Paul Hinze & Contributors
-# Copyright © 2023, Umi
 #
 # This software is released under the BSD 2-Clause "Simplified" License.
-# see https://github.com/Homebrew/homebrew-cask/blob/2477328ebd/LICENSE
+# see https://github.com/Homebrew/homebrew-cask/blob/2103d0407a/LICENSE
+#
+# Modified by VOICEVOX
 
 name: CI
 
@@ -24,23 +25,6 @@ permissions:
   contents: read
 
 jobs:
-  get-changed-casks:
-    outputs:
-      changed-casks: ${{ steps.changed-casks.outputs.all_modified_files }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out Pull Request
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get changed casks
-        id: changed-casks
-        uses: tj-actions/changed-files@v44
-        with:
-          files: |
-            Casks/*.rb
-
   generate-matrix:
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
@@ -62,14 +46,11 @@ jobs:
 
       - name: Generate CI matrix
         id: generate-matrix
-        run: |
-          brew ruby -- "$(brew --repository homebrew/cask)/cmd/lib/generate-matrix.rb" "${{ github.event.pull_request.url }}"
+        run: brew ruby -- "$(brew --repository homebrew/cask)/cmd/lib/generate-matrix.rb" --url="${{ github.event.pull_request.url }}"
 
   test:
     name: ${{ matrix.name }}
-    needs:
-      - get-changed-casks
-      - generate-matrix
+    needs: generate-matrix
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -82,7 +63,7 @@ jobs:
         with:
           core: false
           cask: true
-          test-bot: false
+          test-bot: true
 
       - name: Enable debug mode
         run: |
@@ -98,14 +79,15 @@ jobs:
 
       - name: Clean up CI machine
         run: |
-          if ! brew list --cask visual-studio &>/dev/null; then
-            if ! rm -r '/Applications/Visual Studio.app'; then
-              echo '::warning::Removing Visual Studio is no longer necessary.'
-            fi
+          if [ "${{ matrix.runner }}" == 'macos-12' ] && ! brew uninstall --cask julia && ! rm -r /Applications/Julia-*.app; then
+            echo '::warning::Removing Julia is no longer necessary.'
           fi
 
-          if ! brew uninstall --cask julia && ! rm -r /Applications/Julia-*.app; then
-            echo '::warning::Removing Julia is no longer necessary.'
+          if ! rm /usr/local/share/man/man1/al.1 || \
+             ! sudo rm /etc/paths.d/mono-commands || \
+             ! sudo rm -r /Library/Frameworks/Mono.framework || \
+             ! sudo pkgutil --forget com.xamarin.mono-MDK.pkg; then
+            echo '::warning::Uninstalling Mono is no longer necessary.'
           fi
 
           if ! rm /usr/local/bin/dotnet; then
@@ -114,6 +96,10 @@ jobs:
 
           if ! rm /usr/local/bin/pod; then
             echo '::warning::Removing `cocoapods` symlink is no longer necessary.'
+          fi
+
+          if ! rm /usr/local/bin/chromedriver; then
+            echo '::warning::Removing `chromedriver` symlink is no longer necessary.'
           fi
 
           brew unlink python && brew link --overwrite python
@@ -127,25 +113,10 @@ jobs:
           key: ${{ matrix.runner }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ matrix.runner }}-rubygems-
 
-      - name: Install Homebrew Gems
-        id: gems
-        run: brew install-bundler-gems
-        if: steps.cache.outputs.cache-hit != 'true'
-
-      - name: Run brew readall ${{ matrix.tap }}
-        id: readall
-        run: brew readall '${{ matrix.tap }}'
-        if: >
-          always() &&
-          contains(fromJSON('["success", "skipped"]'), steps.gems.outcome) &&
-          !matrix.skip_readall
-
-      - name: Run brew style ${{ matrix.tap }}
-        run: brew style '${{ matrix.tap }}'
-        if: >
-          always() &&
-          contains(fromJSON('["success", "skipped"]'), steps.readall.outcome) &&
-          !matrix.cask
+      - name: Run brew test-bot --only-tap-syntax
+        id: tap-syntax
+        run: brew test-bot --tap '${{ matrix.tap }}' --only-tap-syntax
+        if: always() && !matrix.cask
 
       - name: Run brew fetch --cask ${{ matrix.cask.token }}
         id: fetch
@@ -154,7 +125,7 @@ jobs:
         timeout-minutes: 30
         if: >
           always() &&
-          contains(fromJSON('["success", "skipped"]'), steps.readall.outcome) &&
+          contains(fromJSON('["success", "skipped"]'), steps.tap-syntax.outcome) &&
           matrix.cask
 
       - name: Run brew audit --cask${{ (matrix.cask && ' ') || ' --tap ' }}${{ matrix.cask.token || matrix.tap }}
@@ -162,10 +133,9 @@ jobs:
         run: |
           brew audit --cask ${{ join(matrix.audit_args, ' ') }}${{ (matrix.cask && ' ') || ' --tap ' }}'${{ matrix.cask.token || matrix.tap }}'
         timeout-minutes: 30
-        if: >-
-          contains(needs.get-changed-casks.outputs.changed-casks, 'Casks/voicevox.rb') &&
+        if: >
           always() &&
-          contains(fromJSON('["success", "skipped"]'), steps.readall.outcome) &&
+          contains(fromJSON('["success", "skipped"]'), steps.tap-syntax.outcome) &&
           (!matrix.cask || steps.fetch.outcome == 'success') &&
           !matrix.skip_audit
 
@@ -250,12 +220,6 @@ jobs:
       - name: Run brew uninstall --cask ${{ matrix.cask.token }}
         run: brew uninstall --cask '${{ matrix.cask.path }}'
         if: always() && steps.install.outcome == 'success' && !fromJSON(steps.info.outputs.manual_installer)
-        timeout-minutes: 30
-
-      - name: Uninstall formula dependencies
-        run: |
-          brew uninstall --formula ${{ join(fromJSON(steps.info.outputs.formula_dependencies), ' ') }}
-        if: always() && steps.install.outcome == 'success' && join(fromJSON(steps.info.outputs.formula_dependencies)) != ''
         timeout-minutes: 30
 
       - name: Uninstall cask dependencies

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -1,0 +1,4 @@
+{
+  "voicevox-dev": "all",
+  "voicevox-preview": "all"
+}


### PR DESCRIPTION
## 内容
エラーが発生する理由は、`brew audit`コマンドが GitHub のプレリリースをバージョンとして認識する Cask に対してエラーを表示するためでした。元々のロジックでは、`Casks/voicevox.rb`ファイルが修正されない限り`brew audit`コマンドは実行されませんでしたが、`Casks/voicevox.rb`と他の`Casks/voicevox-{dev,preview}.rb`ファイルが一緒に修正されると、これらのファイルも検査が行われるため、特定の状況でのみエラーが発生していました。現在は、元のロジックを削除し、`audit_exceptions/github_prerelease_allowlist.json`を追加して、devとpreviewは検査を無視することで解決しました。

## その他
修正ついでに、`ci.yml`も公式Caskレポジトリの最新バージョンと同期させました。
